### PR TITLE
Updates for pmxadapter changes.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/CenturyLinkLabs/panamax-marathon-adapter"
+package main // import "github.com/CenturyLinkLabs/sample-go-adapter"
 
 import (
 	"log"

--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package main // import "github.com/CenturyLinkLabs/sample-go-adapter"
 import (
 	"log"
 	"github.com/CenturyLinkLabs/pmxadapter"
+	"github.com/CenturyLinkLabs/sample-go-adapter/sample"
 )
 
 func main() {
-	adapter := new(SampleAdapter)
+	adapter := new(sample.SampleAdapter)
 	server := pmxadapter.NewServer(adapter)
 
 	log.Printf("Starting Sample Adapter")

--- a/sample/adapter.go
+++ b/sample/adapter.go
@@ -1,4 +1,4 @@
-package main
+package sample
 
 import (
 	"github.com/CenturyLinkLabs/pmxadapter"
@@ -43,4 +43,9 @@ func (a *SampleAdapter) UpdateService(s *pmxadapter.Service) *pmxadapter.Error {
 // Implementation of the PanamaxAdapter DestroyService interface
 func (a *SampleAdapter) DestroyService(id string) *pmxadapter.Error {
 	return nil
+}
+
+// GetMetadata returns metadata for the adapter.
+func (a *SampleAdapter) GetMetadata() pmxadapter.Metadata {
+	return pmxadapter.Metadata{Type: "Sample", Version: "0.1"}
 }


### PR DESCRIPTION
I forgot to update this yesterday after I merged the `pmxadapter` PRs. 

I ran into a problem that I haven't seen before, where `go run main.go` was not building. I discovered that when you run a specific file like that, it will load anything imported from other packages, but it won't load any other files in that same directory. So it couldn't see `adapter.go` and was freaking out. It works if you do `go run *.go`, but that felt weird. I just moved `adapter.go` to `sample/adapter.go` and made a separate `sample` package, since that's probably a more accurate example of what people would want to do anyway.
